### PR TITLE
Add @dotnet-bot to prefix of "retest [job] please"

### DIFF
--- a/content.js
+++ b/content.js
@@ -788,7 +788,7 @@ function processTestFailures(doc,
                             var thisJobName = jobName;
                             var thisPreviousFailureUrl = previousFailureUrl;
                             return function () {
-                                var commentText = "retest " + thisJobName + " please\n// Previous failure: " + thisPreviousFailureUrl + "\n// Retest reason: ";
+                                var commentText = "@dotnet-bot retest " + thisJobName + " please\n// Previous failure: " + thisPreviousFailureUrl + "\n// Retest reason: ";
                                 $("#new_comment_field").val(commentText);
 
                                 var offset = $("#new_comment_field").offset();


### PR DESCRIPTION
While this actually is not needed, it reduces confusion
for community members, whom in the past have throught
the comment was directed at them.
