### PR TITLE
Implement support for other Jenkins hosts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -37,10 +37,13 @@
   },
   "permissions": [
     "storage",
-    "https://ajax.googleapis.com/",
     "https://github.com/*",
     "http://dotnet-ci.cloudapp.net/*",
     "http://ci.roslyn.io/",
     "https://ci.roslyn.io/"
+  ],
+  "optional_permissions": [
+    "http://*/*",
+    "https://*/*"
   ]
 }

--- a/options.html
+++ b/options.html
@@ -118,6 +118,20 @@
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<textarea id="testRerunText" rows="5" cols="75"></textarea>
         </label>
         <br /><br />
+        <label>
+            &nbsp;&nbsp;&nbsp;&nbsp;Host permissions:<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Examples:<br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            <i>https://jenkins-server/*</i><br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Add new host:<br/>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+            <input id="addHostPermissionHostname"></input>
+            <button id="addHostPermission">Add</button><br>
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span id="addHostPermissionError" style="color: red"></span><br />
+            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<textarea id="existingHostPermissions" rows="5" cols="75" disabled="true"></textarea>
+        </label>
+        <br /><br />
+        <br /><br />
 
         <div id="status"></div>
         <button id="save">Save</button>

--- a/options.js
+++ b/options.js
@@ -77,6 +77,35 @@ function restore_options() {
         document.getElementById('defaultIssueLabels').value = items.defaultIssueLabels;
         document.getElementById('testRerunText').value = items.testRerunText;
     });
+    refresh_host_permissions();
+}
+
+function refresh_host_permissions() {
+    chrome.permissions.getAll(function (perms) {
+        document.getElementById('existingHostPermissions').value = perms.origins.join('\n');
+    });
+}
+
+function add_host_permission() {
+    var hostnameInput = document.getElementById('addHostPermissionHostname');
+    var error = document.getElementById('addHostPermissionError');
+    error.textContent = '';
+
+    chrome.permissions.request({
+        origins: [hostnameInput.value]
+    }, function (granted) {
+        if (chrome.runtime.lastError) {
+            error.textContent = 'Error: ' + chrome.runtime.lastError.message;
+        } 
+        else if (granted) {
+            hostnameInput.value = '';
+        } else {
+            error.textContent = 'Error: Permission not granted.';
+        }
+
+        refresh_host_permissions();
+    });
 }
 document.addEventListener('DOMContentLoaded', restore_options);
 document.getElementById('save').addEventListener('click', save_options);
+document.getElementById('addHostPermission').addEventListener('click', add_host_permission);


### PR DESCRIPTION
Adds an initial attempt at allowing the extension to support non-dotnet Jenkins hosts.

To avoid hardcoding the URLs of other hosts we need to add an "optional_permissions" key to manifest.json. By claiming we need `http://*/*` we can request permissions for specific URLs on demand.

Unfortunately, the `chrome.permissions.request` API requires being invoked from an explicit user action
like a button click.

To add to that we can't even access it from a button in the content.js script, it only seems to work in options.js. Googling revealed a few workarounds involving an iframe that sends messages to options.js, but that seems too involved for now.

Instead, I opted for the simplest solution of providing a text box in options.html where you can simply paste a new URL, press the button and Chrome will ask for confirmation.

Fixes #57 

Note: I also dropped `ajax.googleapis.com` since it doesn't seem to be used.
