### PR TITLE
Add initial support for Microsoft Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ StashPop currently only works on [Firefox Nightly builds](https://nightly.mozill
 3. In Nightly, navigate to `about:config` and update `xpinstall.signatures.required` to `false`
 4. Navigate to `about:addons`, choose `Install Add-on From File` from the gear menu, and select the .xpi file you made in step 2
 
+**Edge** (Beta Support - please file any issues you find)
+
+StashPop currently only works on build 14291 of Windows in the [Windows 10 Insider Preview](https://insider.windows.com/) program.  If you're using an appropriate version of Windows 10 and Edge then follow these steps to get set up:
+
+1. Enlist in StashPop or download the source code
+2. In Edge, click the ellipses (...) in the top right corner
+3. Click `Extensions`
+4. Click `Load extension`
+5. Select the directory containing the code that you selected in step 1
+
+Known limitations in Edge:
+- The `options` API isn't implemented so they're not tunable except by updating `content.js` and reloading the extension
+- The `permissions` API isn't implemented so Jenkins test failure data can't be fetched and displayed inline
+
 **Features**
 -------------
 

--- a/content.js
+++ b/content.js
@@ -21,6 +21,30 @@ var option_testRerunText = "testRerunText";
 var option_showCodeReviewInfo = "showCodeReviewInfo";
 var option_codeReviewOptions = "codeReviewOptions";
 
+if (!window.chrome && browser) {
+    // Edge doesn't support the `chrome` class but it does expose `browser`
+    window.chrome = browser;
+}
+
+// Edge doesn't yet support settings so the defaults have to be manually created
+var defaultSettings = {};
+defaultSettings[option_emailIssuesList] = true;
+defaultSettings[option_emailIssue] = true;
+defaultSettings[option_emailPullRequestList] = true;
+defaultSettings[option_emailPullRequest] = true;
+defaultSettings[option_jenkinsOpenDetailsLinksInNewTab] = true;
+defaultSettings[option_jenkinsShowRunTime] = true;
+defaultSettings[option_jenkinsShowFailureIndications] = true;
+defaultSettings[option_jenkinsShowTestFailures] = true;
+defaultSettings[option_jenkinsShowBugFilingButton] = true;
+defaultSettings[option_jenkinsShowRetestButton] = true;
+defaultSettings[option_showCodeReviewInfo] = true;
+defaultSettings[option_codeReviewOptions] = "*;:+1:,:thumbsup:,:shipit:,LGTM;:-1:,:thumbsdown:;Test Signoff";
+defaultSettings[option_issueCreationRouting] = "dotnet/roslyn-internal:dotnet/roslyn";
+defaultSettings[option_nonDefaultTestInfo] = "dotnet/roslyn:vsi:prtest/win/vsi/p0\ndotnet/roslyn-internal:vsi:prtest/win/vsi/p0";
+defaultSettings[option_defaultIssueLabels] = "dotnet:Bug\ndotnet/roslyn-internal:Contributor Pain,Area-Infrastructure";
+defaultSettings[option_testRerunText] = "*:retest {0} please\ndotnet:@dotnet-bot retest {0} please";
+
 document.addEventListener("DOMContentLoaded", function () {
     "use strict";
     log("DOMContentLoaded");
@@ -107,6 +131,8 @@ function reload(firstRun) {
                 option_codeReviewOptions
             ] },
         function (currentSettings) {
+            // Edge currently doesn't pass the settings to this method so we're using the default values
+            currentSettings = currentSettings || defaultSettings;
             if (isIndividualItemPage) {
                 var title = document.getElementsByClassName("js-issue-title")[0].innerHTML;
                 var number = document.getElementsByClassName("gh-header-number")[0].innerHTML.substring(1);

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "StashPop",
+  "author": "David Poeschl",
   "description": "Adds Email and Test Failure Management Features to GitHub",
   "version": "1.1.0",
   "manifest_version": 2,
@@ -34,7 +35,9 @@
     "128": "images/stashpop2_128.png"
   },
   "browser_action": {
-    "default_icon": "images/stashpop_48.png"
+    "default_icon": {
+      "48": "images/stashpop_48.png"
+    }
   },
   "permissions": [
     "storage",


### PR DESCRIPTION
To enable Edge to load StashPop the following changes had to be made:
1. Update the manifest to include the `author` key and fix the `default_icon` value to be a dictionary as specified in the [Chrome extension manifest spec](https://developer.chrome.com/extensions/browserAction).
2. Edge exposes extension functionality through the `browser` object instead of the `chrome` object, so in cases where `chrome` doesn't exist and `browser` does, the functionality is mirrored.
3. Edge doesn't yet support extension settings so a `defaultSettings` object was created with the same values found in `options.js` and if no settings are found, the defaults are used as a fallback.

Known limitations:
- The `permissions` API is currently [under consideration](https://developer.microsoft.com/en-us/microsoft-edge/platform/documentation/extensions/extension-api-roadmap/) and as such isn't currently supported, so attempts by StashPop to display Jenkins test failure data inline fail, although the `Create Issue` buttons, etc. work as expected.
