### PR TITLE
Don't use jQuery for registering pjax event in injectedcode.js

### DIFF
--- a/scripts/injectedcode.js
+++ b/scripts/injectedcode.js
@@ -1,4 +1,4 @@
-$(document).on('pjax:end', function () {
+document.addEventListener('pjax:end', function () {
     // Duplicate the event with a slightly different name
     var e = document.createEvent('Events');
     e.initEvent('_pjax:end', !'bubbles', !'cancelable');


### PR DESCRIPTION
I got the following error in console, which seemed to break the pjax detection:

```
injectedcode.js:1 Uncaught TypeError: $ is not a function
(anonymous function) @ injectedcode.js:1
```

Using jQuery isn't even necessary there as regular document.addEventListener works the same.

Fixes #100 

/cc @dpoeschl 
